### PR TITLE
Remove beta from api_version for taxonomy api

### DIFF
--- a/src/Taxonomy/Services/TaxonomyService.php
+++ b/src/Taxonomy/Services/TaxonomyService.php
@@ -12,7 +12,7 @@ namespace DTS\eBaySDK\Taxonomy\Services;
 
 class TaxonomyService extends \DTS\eBaySDK\Taxonomy\Services\TaxonomyBaseService
 {
-    const API_VERSION = 'v1_beta';
+    const API_VERSION = 'v1';
 
     /**
      * @property array $operations Associative array of operations provided by the service.


### PR DESCRIPTION
Remove beta from taxonomy api url. tag `18.0.3`

Integration eBay APIs Decommission announcement [sc-3392]